### PR TITLE
fixing defaults for feature names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,6 @@ ENV PYTHONPATH "${PYTHONPATH}:/src"
 WORKDIR /tests/
 
 # run tests
-RUN pytest
+RUN xvfb-run pytest
 
 CMD ["/bin/sh", "-c", "xvfb-run python3 -u ./src/minerl3161/main.py"]

--- a/src/minerl3161/models.py
+++ b/src/minerl3161/models.py
@@ -31,21 +31,22 @@ class DQNNet(nn.Module):
         """
         super().__init__()
 
+        feature_names = self._feature_names(
+            state_shape=state_shape,
+            dqn_hyperparams=dqn_hyperparams
+        )             
+
         self.feature_extractor = MineRLFeatureExtraction(
-            state_shape,
-            feature_names=dqn_hyperparams.feature_names
-            if dqn_hyperparams is not None
-            else None,
+            observation_space=state_shape,
+            feature_names=feature_names,
             mlp_hidden_size=dqn_hyperparams.mlp_output_size
             if dqn_hyperparams is not None
-            else None,
+            else layer_size,
         )
 
         sample_input = sample_pt_state(
-            state_shape, 
-            dqn_hyperparams.feature_names
-            if dqn_hyperparams is not None
-            else state_shape.spaces.keys(), 
+            observation_space=state_shape, 
+            features=feature_names, 
             device="cpu",
             batch=1,
         )
@@ -81,3 +82,14 @@ class DQNNet(nn.Module):
         advantage = self.advantage(x)
 
         return v + (advantage - advantage.mean())
+    
+    def _feature_names(self, state_shape, dqn_hyperparams=None):
+        if dqn_hyperparams is not None:
+            feature_names = dqn_hyperparams.feature_names
+        else:
+            try:
+                feature_names = state_shape.spaces.keys()
+            except AttributeError:
+                feature_names = state_shape.keys()   
+        
+        return feature_names

--- a/src/minerl3161/submodel.py
+++ b/src/minerl3161/submodel.py
@@ -72,12 +72,6 @@ class MineRLFeatureExtraction(nn.Module):
 
         self.layers = {}
 
-        if feature_names == None:
-            # set some useful defaults
-            feature_names = [
-                "pov",
-            ]
-
         for feature in feature_names:
             if feature == "pov":
                 # add the CNN


### PR DESCRIPTION
- had set some bad defaults for `MineRLFeatureExtraction` that meant some tests were passing with illogical inputs
- failing some other tests when non-MineRL observation space was used